### PR TITLE
feat: eliminate PWA component duplication (M0)

### DIFF
--- a/src/__tests__/config/pwa-component-deduplication.test.ts
+++ b/src/__tests__/config/pwa-component-deduplication.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for PWA component deduplication
+ * Ensures ServiceWorkerRegistration, InstallPrompt, and I18nInitializer are only rendered once
+ */
+
+describe('PWA Component Deduplication', () => {
+  describe('Layout and ClientWrapper Structure', () => {
+    it('should have PWA components only in layout.tsx, not in ClientWrapper', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+
+      // Read layout.tsx
+      const layoutFile = fs.readFileSync(
+        path.join(process.cwd(), 'src/app/layout.tsx'),
+        'utf8'
+      );
+
+      // Read ClientWrapper.tsx
+      const clientWrapperFile = fs.readFileSync(
+        path.join(process.cwd(), 'src/components/ClientWrapper.tsx'),
+        'utf8'
+      );
+
+      // Layout should contain PWA components
+      expect(layoutFile).toContain('ServiceWorkerRegistration');
+      expect(layoutFile).toContain('InstallPrompt');
+      expect(layoutFile).toContain('I18nInitializer');
+
+      // ClientWrapper should NOT contain PWA components (to avoid duplication)
+      expect(clientWrapperFile).not.toContain('ServiceWorkerRegistration');
+      expect(clientWrapperFile).not.toContain('InstallPrompt');
+      expect(clientWrapperFile).not.toContain('I18nInitializer');
+    });
+
+    it('should have proper component hierarchy without duplication', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+
+      const layoutFile = fs.readFileSync(
+        path.join(process.cwd(), 'src/app/layout.tsx'),
+        'utf8'
+      );
+
+      // Verify proper structure: I18nInitializer wraps SW and InstallPrompt
+      expect(layoutFile).toContain('<I18nInitializer>');
+      expect(layoutFile).toContain('<ServiceWorkerRegistration />');
+      expect(layoutFile).toContain('<InstallPrompt />');
+      expect(layoutFile).toContain('<QueryProvider>');
+      expect(layoutFile).toContain('<ClientWrapper>');
+    });
+
+    it('should have ClientWrapper only containing ToastProvider', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+
+      const clientWrapperFile = fs.readFileSync(
+        path.join(process.cwd(), 'src/components/ClientWrapper.tsx'),
+        'utf8'
+      );
+
+      // ClientWrapper should only have ToastProvider and children
+      expect(clientWrapperFile).toContain('ToastProvider');
+      expect(clientWrapperFile).toContain('{children}');
+
+      // Should not have nested wrapping components
+      expect(clientWrapperFile).not.toContain('QueryProvider');
+      expect(clientWrapperFile).not.toContain('Analytics');
+    });
+  });
+
+  describe('Component Import Validation', () => {
+    it('should only import PWA components where they are used', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+
+      const clientWrapperFile = fs.readFileSync(
+        path.join(process.cwd(), 'src/components/ClientWrapper.tsx'),
+        'utf8'
+      );
+
+      // ClientWrapper should not import PWA components
+      expect(clientWrapperFile).not.toContain("import I18nInitializer");
+      expect(clientWrapperFile).not.toContain("import ServiceWorkerRegistration");
+      expect(clientWrapperFile).not.toContain("import InstallPrompt");
+
+      // Should only import what it uses
+      expect(clientWrapperFile).toContain("import { ToastProvider }");
+    });
+  });
+});

--- a/src/components/ClientWrapper.tsx
+++ b/src/components/ClientWrapper.tsx
@@ -1,23 +1,13 @@
 'use client';
 
 import React from 'react';
-// Remove direct import of I18nextProvider and i18n instance
-// import { I18nextProvider } from 'react-i18next';
-// import i18n from '../i18n';
-import I18nInitializer from './I18nInitializer';
-import InstallPrompt from './InstallPrompt';
-import ServiceWorkerRegistration from './ServiceWorkerRegistration';
 import { ToastProvider } from '@/contexts/ToastProvider';
 
 const ClientWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
-    <I18nInitializer>
-      <ServiceWorkerRegistration />
-      <ToastProvider>
-        {children}
-        <InstallPrompt />
-      </ToastProvider>
-    </I18nInitializer>
+    <ToastProvider>
+      {children}
+    </ToastProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- Remove duplicate PWA components from ClientWrapper.tsx
- ServiceWorkerRegistration, InstallPrompt, and I18nInitializer are already in layout.tsx
- Eliminates double rendering that was causing potential issues

## Changes Made
- **ClientWrapper.tsx**: Removed ServiceWorkerRegistration, InstallPrompt, and I18nInitializer imports and usage
- **New test**: Added comprehensive test suite to prevent future duplication
- **M0 Checklist**: Completes two remaining M0 items for PWA and i18n deduplication

## Test Plan
- [x] All existing tests pass
- [x] Build succeeds without errors  
- [x] New deduplication test validates proper structure
- [x] Manual verification of component hierarchy

## Before/After Structure

### Before (Problematic)
```
layout.tsx:
  <I18nInitializer>              // 1st instance
    <ServiceWorkerRegistration />  // 1st instance  
    <InstallPrompt />              // 1st instance
    <QueryProvider>
      <ClientWrapper>
        <I18nInitializer>          // 2nd instance ❌
          <ServiceWorkerRegistration />  // 2nd instance ❌
          <InstallPrompt />              // 2nd instance ❌
```

### After (Fixed)
```
layout.tsx:
  <I18nInitializer>              // ✅ Single instance
    <ServiceWorkerRegistration />  // ✅ Single instance
    <InstallPrompt />              // ✅ Single instance
    <QueryProvider>
      <ClientWrapper>              // ✅ Only ToastProvider
        <ToastProvider>
          {children}
```

## M0 Progress
This PR completes these M0 checklist items:
- [x] PWA: render ServiceWorkerRegistration and InstallPrompt only once (FIX_PLAN §3)
- [x] i18n: ensure only one I18nInitializer wraps the app (no duplication)

🤖 Generated with [Claude Code](https://claude.ai/code)